### PR TITLE
Correct the compatibility description

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ pip install fairgbm/python-package/
 ```
 
 > **Note**
-> Compatibility is only maintained with **Linux OS**.
+> Compatibility is only maintained with **Ubuntu OS**.
 > 
-> If you don't have access to a Linux machine we advise using the free Google 
+> If you don't have access to a Ubuntu machine we advise using the free Google 
 > Colab service ([example Colab notebook here](https://colab.research.google.com/github/AndreFCruz/fairgbm-fork/blob/add-colab-example/examples/FairGBM-python-notebooks/FairGBM_example_for_equalized_odds_%5Bgoogle_colab%5D.ipynb)).
 >
 > We also provide a docker image that can be useful for non-linux platforms, run: ```docker run -p 8888:8888 ndrcrz/fairgbm-miniconda``` for a jupyter notebook environment with `fairgbm` installed.
@@ -74,6 +74,8 @@ Although it is recommended to use the python package directly on your local x86-
 using this docker image is an option for users on other platforms (docker image was tested on an M1 Mac).
 
 The Dockerfile is available [here](examples/FairGBM-python-notebooks/Dockerfile).
+
+You can also set up your own environment as long as you build a docker image like this [here](examples/Dockerfile)
 
 
 ## Getting started

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -1,0 +1,10 @@
+# Basic image setup
+# FROM ubuntu:latest
+FROM --platform=linux/amd64 ubuntu:latest
+
+RUN apt-get update && apt-get install -y wget
+RUN apt-get update && apt-get install vim -y
+
+# Install Miniconda
+# RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+# Recommend: do that after getting into the container


### PR DESCRIPTION
As people noticed (https://github.com/feedzai/fairgbm/issues/45), fairgbm is not supported on macOS. Besides, I tested fairgbm on Cent OS and RHEL8 systems, and it didn't work as well. So I don't think the statement---and I quote, "Note Compatibility is only maintained with Linux OS."---is correct, because the only Linux where I know it works is Ubuntu, although so many other Linux systems out there and I didn't test them all. Here I attached the errors for your information.

### Error info
Running fairgbm on RHEL8 (Linux)
```shell
>>> import fairgbm
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "~/miniconda3/envs/ensem/lib/python3.8/site-packages/fairgbm/__init__.py", line 8, in <module>
    from .basic import Booster, Dataset, register_logger
  File "~/miniconda3/envs/ensem/lib/python3.8/site-packages/fairgbm/basic.py", line 95, in <module>
    _LIB = _load_lib()
  File "~/miniconda3/envs/ensem/lib/python3.8/site-packages/fairgbm/basic.py", line 86, in _load_lib
    lib = ctypes.cdll.LoadLibrary(lib_path[0])
  File "~/miniconda3/envs/ensem/lib/python3.8/ctypes/__init__.py", line 451, in LoadLibrary
    return self._dlltype(name)
  File "~/miniconda3/envs/ensem/lib/python3.8/ctypes/__init__.py", line 373, in __init__
    self._handle = _dlopen(self._name, mode)
OSError: /lib64/libm.so.6: version `GLIBC_2.29' not found (required by ~/miniconda3/envs/ensem/lib/python3.8/site-packages/fairgbm/lib_lightgbm.so)
>>>
```

Running fairgbm on CentOS 7 (Linux)
```shell
>>> import fairgbm
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "~/Software/anaconda3/envs/ensem/lib/python3.6/site-packages/fairgbm/__init__.py", line 8, in <module>
    from .basic import Booster, Dataset, register_logger
  File "~/Software/anaconda3/envs/ensem/lib/python3.6/site-packages/fairgbm/basic.py", line 95, in <module>
    _LIB = _load_lib()
  File "~/Software/anaconda3/envs/ensem/lib/python3.6/site-packages/fairgbm/basic.py", line 86, in _load_lib
    lib = ctypes.cdll.LoadLibrary(lib_path[0])
  File "~/Software/anaconda3/envs/ensem/lib/python3.6/ctypes/__init__.py", line 426, in LoadLibrary
    return self._dlltype(name)
  File "~/Software/anaconda3/envs/ensem/lib/python3.6/ctypes/__init__.py", line 348, in __init__
    self._handle = _dlopen(self._name, mode)
OSError: /lib64/libm.so.6: version `GLIBC_2.27' not found (required by ~/Software/anaconda3/envs/ensem/lib/python3.6/site-packages/fairgbm/lib_lightgbm.so)
>>> 
```

### Extra
Running fairgbm on MacOS (Unix)
```shell
>>> import lightgbm
>>> import fairgbm
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "~/Software/miniconda3/envs/ensem/lib/python3.8/site-packages/fairgbm/__init__.py", line 8, in <module>
    from .basic import Booster, Dataset, register_logger
  File "~/Software/miniconda3/envs/ensem/lib/python3.8/site-packages/fairgbm/basic.py", line 95, in <module>
    _LIB = _load_lib()
  File "~/Software/miniconda3/envs/ensem/lib/python3.8/site-packages/fairgbm/basic.py", line 86, in _load_lib
    lib = ctypes.cdll.LoadLibrary(lib_path[0])
  File "~/Software/miniconda3/envs/ensem/lib/python3.8/ctypes/__init__.py", line 451, in LoadLibrary
    return self._dlltype(name)
  File "~/Software/miniconda3/envs/ensem/lib/python3.8/ctypes/__init__.py", line 373, in __init__
    self._handle = _dlopen(self._name, mode)
OSError: dlopen(~/Software/miniconda3/envs/ensem/lib/python3.8/site-packages/fairgbm/lib_lightgbm.so, 0x0006): tried: '~/Software/miniconda3/envs/ensem/lib/python3.8/site-packages/fairgbm/lib_lightgbm.so' (not a mach-o file), '/System/Volumes/Preboot/Cryptexes/OS/~/Software/miniconda3/envs/ensem/lib/python3.8/site-packages/fairgbm/lib_lightgbm.so' (no such file), '~/Software/miniconda3/envs/ensem/lib/python3.8/site-packages/fairgbm/lib_lightgbm.so' (not a mach-o file)
```